### PR TITLE
Allow individual images to fail and report which ones fail.

### DIFF
--- a/phrosty/imagesubtraction.py
+++ b/phrosty/imagesubtraction.py
@@ -1,6 +1,7 @@
 __all__ = [ 'sky_subtract', 'stampmaker' ]
 
 # IMPORTS Standard:
+from astropy.io import fits
 import numpy as np
 import pathlib
 import random
@@ -63,9 +64,10 @@ def sky_subtract( img, temp_dir=None ):
         if isinstance( origimg, snappl.image.FITSImageOnDisk ):
             img = origimg.uncompressed_version( include=['data'] )
         else:
-            img = snappl.image.FITSImageOnDisk( path=tmpimpath )
+            # Can take out header arg when snappl issue #77 is resolved.
+            img = snappl.image.FITSImage( path=tmpimpath, header=fits.header.Header() )
             img.data = origimg.data
-            img.save_data()
+            img.save_data( which='data' )
 
         SNLogger.debug( "Calling SEx_SkySubtract.SSS..." )
         ( _SKYDIP, _SKYPEAK, _PixA_skysub,
@@ -78,10 +80,12 @@ def sky_subtract( img, temp_dir=None ):
                                                          DETECT_THRESH=1.5, DETECT_MINAREA=5,
                                                          DETECT_MAXAREA=0,
                                                          VERBOSE_LEVEL=2, MDIR=None)
+
+
         SNLogger.debug( "...back from SEx_SkySubtract.SSS" )
 
-        subim = snappl.image.FITSImageOnDisk( path=tmpsubpath )
-        detmaskim = snappl.image.FITSImageOnDisk( path=tmpdetmaskpath )
+        subim = snappl.image.FITSImage( path=tmpsubpath )
+        detmaskim = snappl.image.FITSImage( path=tmpdetmaskpath )
         skyrms = np.median( PixA_skyrms )
         return subim, detmaskim, skyrms
 

--- a/phrosty/pipeline.py
+++ b/phrosty/pipeline.py
@@ -94,8 +94,7 @@ class PipelineImage:
         self.psf_data = None
 
     def run_sky_subtract( self, mp=True ):
-        """
-        Run sky subtraction using Source Extractor.
+        """Run sky subtraction using Source Extractor.
 
         Parameters
         ----------
@@ -108,7 +107,7 @@ class PipelineImage:
             Tuple containing sky subtracted image, detection
             mask array, and sky RMS value. 
             Output of phrosty.imagesubtraction.sky_subtract().
-        """        
+        """
         try:
             return sky_subtract( self.image )
         except Exception as ex:
@@ -116,8 +115,7 @@ class PipelineImage:
             raise
 
     def save_sky_subtract_info( self, info ):
-        """
-        Saves the sky-subtracted image, detection mask array,
+        """Saves the sky-subtracted image, detection mask array,
         and sky RMS values to attributes. 
 
         Parameters
@@ -125,7 +123,7 @@ class PipelineImage:
         info : tuple
             Output of self.run_sky_subtract(). See documentation
             for phrosty.imagesubtraction.sky_subtract().
-        """        
+        """
         try:
             SNLogger.debug( f"Saving sky_subtract info for path {info[0]}" )
             self.skysub_img = info[0]
@@ -177,8 +175,7 @@ class PipelineImage:
             return None
 
     def keep_psf_data( self, psf_data ):
-        """
-        Save PSF data to attribute. If self.get_psf() failed,
+        """Save PSF data to attribute. If self.get_psf() failed,
         then the image is recorded as a failure.
 
         Parameters
@@ -298,8 +295,7 @@ class Pipeline:
 
 
     def _read_csv( self, csvfile ):
-        """
-        Reads input csv files with columns:
+        """Reads input csv files with columns:
         'path pointing sca mjd band'.
 
         Parameters
@@ -332,21 +328,20 @@ class Pipeline:
 
 
     def sky_sub_all_images( self ):
-        """
-        Sky subtracts all snappl.image.Image objects in 
+        """Sky subtracts all snappl.image.Image objects in 
         self.science_images and self.template_images using
         Source Extractor.
 
         Contains its own error logging function, log_error().
 
-        """        
+        """
 
         # Currently, this writes out a bunch of FITS files.  Further refactoring needed
         #   to support more general image types.
         all_imgs = self.science_images.copy()     # shallow copy
         all_imgs.extend( self.template_images )
 
-        def log_error( img, x ):   
+        def log_error( img, x ):
 
             SNLogger.error( f"Sky subtraction failure on {img.image.path}: {x}" )
             self.failures['skysub'].append( f'{img.image.band} {img.image.pointing} {img.image.sca}' )
@@ -364,8 +359,7 @@ class Pipeline:
                 img.save_sky_subtract_info( img.run_sky_subtract( mp=False ) )
 
     def get_psfs( self ):
-        """
-        Retrieve PSFs for all snappl.image.Image objects in
+        """Retrieve PSFs for all snappl.image.Image objects in
         self.science_images and self.template_images.
 
         Contains its own error logging function, log_error().
@@ -385,7 +379,7 @@ class Pipeline:
                     # callback_partial = partial( img.save_psf_path, all_imgs )
                     pool.apply_async( img.get_psf, (self.diaobj.ra, self.diaobj.dec), {},
                                       callback=img.keep_psf_data,
-                                      error_callback=partial(log_error,img) )
+                                      error_callback=partial(log_error, img) )
                 pool.close()
                 pool.join()
         else:
@@ -598,8 +592,7 @@ class Pipeline:
         return results_dict
 
     def add_to_results_dict( self, one_pair ):
-        """
-        Record results from self.make_phot_info_dict() to the
+        """Record results from self.make_phot_info_dict() to the
         aggregate dictionary for the entire light curve.
 
         Parameters
@@ -619,9 +612,7 @@ class Pipeline:
         SNLogger.debug( "Done adding to results dict" )
 
     def save_stamp_paths( self, sci_image, templ_image, paths ):
-        """
-
-        Helper function for recording the stamp paths returned in
+        """Helper function for recording the stamp paths returned in
         self.do_stamps.
 
         Parameters
@@ -641,8 +632,7 @@ class Pipeline:
         sci_image.diff_var_stamp_path[ templ_image.image.name ] = paths[2]
 
     def do_stamps( self, sci_image, templ_image ):
-        """
-        Make stamps from the zero point image, decorrelated
+        """Make stamps from the zero point image, decorrelated
         difference image, and variance image centered at the
         location of the supernova.
 
@@ -659,7 +649,7 @@ class Pipeline:
             Paths to the stamps corresponding to the zero point image,
             decorrelated difference image, and variance image centered
             at the location of the supernova.
-        """        
+        """
 
         try:
             zptim = FITSImageOnDisk( sci_image.decorr_zptimg_path[ templ_image.image.name ] )
@@ -694,9 +684,9 @@ class Pipeline:
             self.failures['make_stamps'].append({'science': f'{sci_image.image.band} {sci_image.image.pointing} {sci_image.image.sca}',
                                                  'template': f'{templ_image.image.band} {templ_image.image.pointing} {templ_image.image.sca}'
                                                 })
+
     def make_lightcurve( self ):
-        """
-        Collect all results from photometry in one dictionary.
+        """Collect all results from photometry in one dictionary.
         Write the output to a csv as a table.
 
         Contains its own error logging function, log_error().
@@ -705,7 +695,7 @@ class Pipeline:
         -------
         pathlib.Path
             Path to output csv file that contains a light curve.
-        """        
+        """
         SNLogger.info( "Making lightcurve." )
 
         self.results_dict = {
@@ -760,8 +750,7 @@ class Pipeline:
         return results_savepath
 
     def write_fits_file( self, data, header, savepath ):
-        """
-        Helper function for writing fits files.
+        """Helper function for writing fits files.
 
         Parameters
         ----------
@@ -784,15 +773,14 @@ class Pipeline:
             raise
 
     def clear_contents( self, directory ):
-        """
-        Delete contents of a directory. Used to clear temporary
+        """Delete contents of a directory. Used to clear temporary
         files.
 
         Parameters
         ----------
         directory : pathlib.Path
             Path to directory to empty.
-        """        
+        """
         for f in directory.iterdir():
             try:
                 if f.is_dir():

--- a/phrosty/pipeline.py
+++ b/phrosty/pipeline.py
@@ -93,14 +93,10 @@ class PipelineImage:
         self.psfobj = None
         self.psf_data = None
 
-        self._omg = False  # Error variable
-
     def run_sky_subtract( self, mp=True ):
-        self._omg = False
         try:
             return sky_subtract( self.image )
         except Exception as ex:
-            self._omg = True
             SNLogger.exception( ex )
             raise
 
@@ -293,8 +289,6 @@ class Pipeline:
     def get_psfs( self ):
         all_imgs = self.science_images.copy()     # shallow copy
         all_imgs.extend( self.template_images )
-
-        self._omg = False
 
         def log_error( img, x ):
             SNLogger.error( f"get_psf failure on {img.image.path}: {x}" )

--- a/phrosty/pipeline.py
+++ b/phrosty/pipeline.py
@@ -124,6 +124,7 @@ class PipelineImage:
             Output of self.run_sky_subtract(). See documentation
             for phrosty.imagesubtraction.sky_subtract().
         """
+
         try:
             SNLogger.debug( f"Saving sky_subtract info for path {info[0]}" )
             self.skysub_img = info[0]
@@ -131,7 +132,8 @@ class PipelineImage:
             self.skyrms = info[2]
 
         except:
-            pipeline.failures['skysub'].append(f'{self.image.band} {self.image.pointing} {self.image.sca}')
+            if self.skysub_img is None or self.detmask_img is None or self.skyrms is None:
+                pipeline.failures['skysub'].append(f'{self.image.band} {self.image.pointing} {self.image.sca}')
 
     def get_psf( self, ra, dec ):
         """Get the at the right spot on the image.
@@ -253,7 +255,7 @@ class Pipeline:
              Toggle verbose output.
 
         """
-
+        
         SNLogger.setLevel( logging.DEBUG if verbose else logging.INFO )
         self.config = Config.get()
         self.imgcol = imgcol

--- a/phrosty/pipeline.py
+++ b/phrosty/pipeline.py
@@ -94,6 +94,21 @@ class PipelineImage:
         self.psf_data = None
 
     def run_sky_subtract( self, mp=True ):
+        """
+        Run sky subtraction using Source Extractor.
+
+        Parameters
+        ----------
+        mp : bool, optional
+            Toggle multiprocessing, by default True
+
+        Returns
+        -------
+        tuple
+            Tuple containing sky subtracted image, detection
+            mask array, and sky RMS value. 
+            Output of phrosty.imagesubtraction.sky_subtract().
+        """        
         try:
             return sky_subtract( self.image )
         except Exception as ex:
@@ -101,6 +116,16 @@ class PipelineImage:
             raise
 
     def save_sky_subtract_info( self, info ):
+        """
+        Saves the sky-subtracted image, detection mask array,
+        and sky RMS values to attributes. 
+
+        Parameters
+        ----------
+        info : tuple
+            Output of self.run_sky_subtract(). See documentation
+            for phrosty.imagesubtraction.sky_subtract().
+        """        
         try:
             SNLogger.debug( f"Saving sky_subtract info for path {info[0]}" )
             self.skysub_img = info[0]
@@ -117,6 +142,11 @@ class PipelineImage:
         ----------
           ra, dec : float
              The coordinates in decimal degrees where we want the PSF.
+        
+        Returns
+        -------
+        np.array
+            PSF stamp. If this function fails, None is returned.
 
         """
 
@@ -147,6 +177,17 @@ class PipelineImage:
             return None
 
     def keep_psf_data( self, psf_data ):
+        """
+        Save PSF data to attribute. If self.get_psf() failed,
+        then the image is recorded as a failure.
+
+        Parameters
+        ----------
+        psf_data : np.array
+            PSF stamp.
+
+        """
+
         self.psf_data = psf_data
 
         if self.psf_data is None:

--- a/phrosty/tests/conftest.py
+++ b/phrosty/tests/conftest.py
@@ -6,7 +6,7 @@ import tox # noqa: F401
 from tox.pytest import init_fixture # noqa: F401
 
 from snpit_utils.config import Config
-from snappl.image import FITSImageOnDisk, ManualFITSImage
+from snappl.image import FITSImageOnDisk, FITSImageStdHeaders
 from snappl.diaobject import DiaObject
 from snappl.imagecollection import ImageCollection
 
@@ -184,5 +184,13 @@ def nan_image( ou2024_image_collection ):
     nan_arr = np.empty((4088,4088))
     nan_arr[:] = np.nan
 
-    nan_img = ManualFITSImage(header=ou_header, data=nan_arr, pointing=35198, sca=2)
+    # NOTE: path='/dev/null' because at this time, snappl requires a path to instantiate
+    # a FITSImage object.
+    nan_img = FITSImageStdHeaders( path='/dev/null', 
+                                   header=ou_header, 
+                                   data=nan_arr,
+                                   noise=nan_arr,
+                                   flags=nan_arr )
+    nan_img.band = 'Y106'
+
     return nan_img

--- a/phrosty/tests/conftest.py
+++ b/phrosty/tests/conftest.py
@@ -177,20 +177,17 @@ def two_ou2024_science_images( ou2024_image_collection ):
     return img1, img2
 
 @pytest.fixture
-def nan_image( ou2024_image_collection ):
-    ou_img = ou2024_image_collection.get_image( pointing=35198, sca=2, band='Y106' )
-    ou_header = ou_img.get_fits_header()
-
+def nan_image():
     nan_arr = np.empty((4088,4088))
     nan_arr[:] = np.nan
 
     # NOTE: path='/dev/null' because at this time, snappl requires a path to instantiate
     # a FITSImage object.
     nan_img = FITSImageStdHeaders( path='/dev/null', 
-                                   header=ou_header, 
-                                   data=nan_arr,
-                                   noise=nan_arr,
-                                   flags=nan_arr )
+                                   data=nan_arr
+                                 )
     nan_img.band = 'Y106'
+    nan_img.pointing = -1  # So it's not real and doesn't interpret.
+    nan_img.sca = 1
 
     return nan_img

--- a/phrosty/tests/conftest.py
+++ b/phrosty/tests/conftest.py
@@ -1,3 +1,4 @@
+import numpy as np
 import pytest # noqa: F401
 import pathlib
 
@@ -5,7 +6,7 @@ import tox # noqa: F401
 from tox.pytest import init_fixture # noqa: F401
 
 from snpit_utils.config import Config
-from snappl.image import FITSImageOnDisk
+from snappl.image import FITSImageOnDisk, ManualFITSImage
 from snappl.diaobject import DiaObject
 from snappl.imagecollection import ImageCollection
 
@@ -174,3 +175,14 @@ def two_ou2024_science_images( ou2024_image_collection ):
     img1 = ou2024_image_collection.get_image( pointing=35198, sca=2, band='Y106' )
     img2 = ou2024_image_collection.get_image( pointing=39790, sca=15, band='Y106' )
     return img1, img2
+
+@pytest.fixture
+def nan_image( ou2024_image_collection ):
+    ou_img = ou2024_image_collection.get_image( pointing=35198, sca=2, band='Y106' )
+    ou_header = ou_img.get_fits_header()
+
+    nan_arr = np.empty((4088,4088))
+    nan_arr[:] = np.nan
+
+    nan_img = ManualFITSImage(header=ou_header, data=nan_arr, pointing=35198, sca=2)
+    return nan_img

--- a/phrosty/tests/test_pipeline.py
+++ b/phrosty/tests/test_pipeline.py
@@ -1,4 +1,5 @@
 import os
+import numpy as np
 import pytest
 from phrosty.pipeline import Pipeline
 
@@ -70,16 +71,27 @@ def test_pipeline_run( object_for_tests, ou2024_image_collection,
     #   directories for tests and for running... so don't do that... but the
     #   way we're set up right now, you probably are.
 
+
 @pytest.mark.skipif( os.getenv("SKIP_GPU_TESTS", 0 ), reason="SKIP_GPU_TESTS is set" )
 def test_pipeline_failures( object_for_tests, ou2024_image_collection,
-                            one_ou2024_template_image, two_ou2024_science_images ):
+                            one_ou2024_template_image, two_ou2024_science_images,
+                            nan_image ):
     pip = Pipeline( object_for_tests, ou2024_image_collection, 'Y106',
                     science_images=two_ou2024_science_images,
                     template_images=[one_ou2024_template_image],
                     nprocs=2, nwrite=3 )
-    
+
     # First, check the images as-is. Make sure there are no failures.
     for key in pip.failures:
         assert len(pip.failures[key]) == 0
-
     
+    new_test_imgs = [nan_image, two_ou2024_science_images[1]]
+
+    pip = Pipeline( object_for_tests, ou2024_image_collection, 'Y106',
+                science_images=new_test_imgs,
+                template_images=[one_ou2024_template_image],
+                nprocs=2, nwrite=3 )
+
+    for key in pip.failures:
+        print(key)
+        print(len(pip.failures[key]))


### PR DESCRIPTION
Adds code to pipeline.py to collect images that fail at various steps in the pipeline. Works for images that fail in make_lightcurve. The other steps are untested, and no tests have been written yet.