### PR TITLE
Fix KeyError in add_to_results_dict failure branch (one_pair['band'] -> self.band)

### DIFF
--- a/changes/194.bugfix.rst
+++ b/changes/194.bugfix.rst
@@ -1,0 +1,1 @@
+Fixed KeyError when recording make_lightcurve failures with catchfailures enabled.

--- a/phrosty/pipeline.py
+++ b/phrosty/pipeline.py
@@ -690,10 +690,10 @@ class Pipeline:
         if not one_pair['success']:
             SNLogger.debug( "Failure in make_lightcurve!" )
             if self.catchfailures:
-                self.failures['make_lightcurve'].append({'science': f"{one_pair['band']} \
+                self.failures['make_lightcurve'].append({'science': f"{self.band} \
                                                                     {one_pair['observation_id']} \
                                                                     {one_pair['sca']}",
-                                                        'template': f"{one_pair['band']} \
+                                                        'template': f"{self.band} \
                                                                     {one_pair['template_observation_id']} \
                                                                     {one_pair['template_sca']}"
                                                         })


### PR DESCRIPTION
The `catchfailures` branch of `add_to_results_dict` reads `one_pair['band']`, but the dict produced by `make_phot_info_dict` never contains a `'band'` key (it is also not in `req_results_keys`, so the NaN pre-init doesn't cover it). Result: when a lightcurve pair fails AND `catchfailures` is enabled, recording the failure raises `KeyError: 'band'` — the failure-catching path is itself the failing path. Hit this in practice with `catchfailures` enabled.

Fix is minimal: use `self.band` (the pipeline is single-band per instance; the same pattern is already used at the other failure-record sites, e.g. `make_stamps`).

Noticed #178 is reworking this area — happy for this to be folded into that branch instead if easier (a regression test for it would fit naturally beside the new failure-path tests there); filing separately so it isn't lost. Changelog fragment to follow once I have the PR number.
