### PR TITLE
Populate NEA, sky_rms, pix_x, pix_y output columns (currently always NaN)

### DIFF
--- a/changes/195.bugfix.rst
+++ b/changes/195.bugfix.rst
@@ -1,0 +1,1 @@
+NEA, sky_rms, pix_x, and pix_y output columns are now populated (previously always NaN).

--- a/phrosty/pipeline.py
+++ b/phrosty/pipeline.py
@@ -666,8 +666,14 @@ class Pipeline:
             results_dict['zpt'] = sci_image.image.zeropoint
             # Populate columns that stock phrosty declares but does not yet write
             #   (NEA / sky_rms / pix_x / pix_y were left as NaN upstream).
-            results_dict['pix_x'] = float( pxcoords[0] )
-            results_dict['pix_y'] = float( pxcoords[1] )
+            # pix_x/pix_y are documented as the SN position on the *detector*
+            #   (4088^2 SCA), so project the sky coord through the original
+            #   science-image WCS -- NOT `pxcoords`, which is stamp-local (~50,50
+            #   on the 100x100 diff cutout) and is only valid for phot_at_coords.
+            det_x, det_y = sci_image.image.get_wcs().world_to_pixel( self.diaobj.ra,
+                                                                     self.diaobj.dec )
+            results_dict['pix_x'] = float( det_x )
+            results_dict['pix_y'] = float( det_y )
             results_dict['sky_rms'] = sci_image.skyrms
             # Noise-equivalent area (px^2); scale-invariant so it's correct whether or
             #   not the PSF stamp is normalized to unit sum.

--- a/phrosty/pipeline.py
+++ b/phrosty/pipeline.py
@@ -664,6 +664,14 @@ class Pipeline:
             # Add additional info to the results dictionary so it can be merged into a nice file later.
             SNLogger.debug( "...make_phot_info_dict getting zeropoint" )
             results_dict['zpt'] = sci_image.image.zeropoint
+            # Populate columns that stock phrosty declares but does not yet write
+            #   (NEA / sky_rms / pix_x / pix_y were left as NaN upstream).
+            results_dict['pix_x'] = float( pxcoords[0] )
+            results_dict['pix_y'] = float( pxcoords[1] )
+            results_dict['sky_rms'] = sci_image.skyrms
+            # Noise-equivalent area (px^2); scale-invariant so it's correct whether or
+            #   not the PSF stamp is normalized to unit sum.
+            results_dict['NEA'] = float( psf_img.data.sum()**2 / np.sum( psf_img.data**2 ) )
             results_dict['success'] = True
 
         except Exception as e:

--- a/phrosty/tests/test_pipeline.py
+++ b/phrosty/tests/test_pipeline.py
@@ -189,6 +189,24 @@ def test_pipeline_run( object_for_tests, ou2024_image_collection,
         assert int(pair['template_sca']) == int(one_ou2024_template_image.sca)
         assert float(pair['zpt']) == pytest.approx( 32.6617, abs=0.0001 )
 
+        # Regression test for #195 : NEA, sky_rms, pix_x, pix_y were declared
+        #   in the output schema but never assigned, so every lightcurve
+        #   carried NaN in all four columns.
+        assert np.isfinite( float(pair['NEA']) )
+        assert float(pair['NEA']) > 0.
+        assert np.isfinite( float(pair['sky_rms']) )
+        assert float(pair['sky_rms']) > 0.
+        # pix_x/pix_y are the SN position on the *detector* (per the schema
+        #   comments in make_lightcurve_dict): the object's sky coordinate
+        #   projected through the science image WCS, NOT the stamp-local
+        #   coordinates used for photometry (which would be ~(50, 50)).
+        expected_x, expected_y = img.get_wcs().world_to_pixel( object_for_tests.ra,
+                                                               object_for_tests.dec )
+        assert float(pair['pix_x']) == pytest.approx( float(expected_x), abs=0.01 )
+        assert float(pair['pix_y']) == pytest.approx( float(expected_y), abs=0.01 )
+        assert 0. <= float(pair['pix_x']) <= 4088.
+        assert 0. <= float(pair['pix_y']) <= 4088.
+
     # Tests aren't exactly reproducible from one run to the next,
     #   because some classes (including the galsim PSF that we use right
     #   now) have random numbers in them, and at the moment we aren't


### PR DESCRIPTION
`req_results_keys` declares `NEA`, `sky_rms`, `pix_x`, `pix_y` and the aggregate results dict allocates them, but `make_phot_info_dict` never assigns them — every output lightcurve carries NaN in all four columns.

This fills them at the natural point (right after `zpt`):
- `pix_x`/`pix_y`: SN position on the detector, via the science image WCS (`world_to_pixel(ra, dec)`). Deliberately NOT `pxcoords`, which is stamp-local (~50,50 on the diff cutout) and only valid for `phot_at_coords`.
- `sky_rms`: `sci_image.skyrms`.
- `NEA`: `psf_img.data.sum()**2 / np.sum(psf_img.data**2)` (px², per the column comment's definition).

If NEA was intended to be measured differently, happy to adjust — main point is the columns stop being silently NaN. Changelog fragment to follow once I have the PR number.
