### PR TITLE
Phrosty runs ASDF

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ This is lightcurve software being developed for the Roman Supernova Project Infr
 Prerequisites and Environment
 -----------------------------
 
-Although SFFT works in both CPU and GPU environments, currently some of the code in *phrosty* requires a CUDA-based GPU.  It requires a machine with an NVidia GPU that has at least 20MB (or more) of GPU RAM.  The Perlmutter GPU nodes at NERSC (with 40GB of GPU RAM) meet this requirement, but consumer graphics cards with only 12GB of RAM aren't sufficient.
+Although SFFT works in both CPU and GPU environments, currently some of the code in *phrosty* requires a CUDA-based GPU.  It requires a machine with an NVidia GPU that has at least 20GB (or more) of GPU RAM.  The Perlmutter GPU nodes at NERSC (with 40GB of GPU RAM) meet this requirement, but consumer graphics cards with only 12GB of RAM aren't sufficient.
 
 A number of standard python libraries are required, all of which may be installed from pip, including ``numpy``, ``scipy``, ``astropy``, ``scikit-image``, ``cupy-cuda12x``, ``pandas``, ``requests``, ``fitsio``, ``pyarrow``, ``fastparquet``, and (maybe?) ``nvmath-python[cu12]``.  If you are using OpenUniverse images, *phrosty* also requires ``galsim``, which may be installed from pip; and ``roman_imsim``, which may be git cloned from ``https://github.com/matroxel/roman_imsim.git``. *However*, if you use the provided containerized environments, the prerequisite packages have been dealt with for you.
 

--- a/changes/199.feature.rst
+++ b/changes/199.feature.rst
@@ -1,0 +1,1 @@
+phrosty can now ingest ASDF images. Images are still converted to FITS inside the pipeline. Source Extractor was removed as the sky-subtraction algorithm and was replaced with photutils. Some minor improvements based on other PRs were incorporated. 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -450,7 +450,7 @@ The SNe Ia in the sims are object IDs `11` and `21`. We are going to test on `11
         -r 9.366435 \
         -d -43.958825 \
         -ic manual_rdm \
-        --base-path /rick/romanisim/ \
+        --base-path /ricksims/ \
         -t phrosty/tests/11_instances_templates_1.csv \
         -s phrosty/tests/11_instances_science_2.csv \
         -p 1 -w 1 \

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -442,7 +442,7 @@ The SNe Ia in the sims are object IDs `11` and `21`. We are going to test on `11
   SNPIT_CONFIG=phrosty/tests/phrosty_test_config_smdc.yaml python phrosty/pipeline.py \
         --oid 11 \
         -oc manual \
-        -b Y106 \
+        -b J129 \
         -r 9.366435 \
         -d -43.958825 \
         -ic manual_rdm \

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -439,7 +439,7 @@ If you are in the Singularity container discussed above, `/home/rkessler/` maps 
 
 The SNe Ia in the sims are object IDs `11` and `21`. We are going to test on `11`. Do all of the things above, and from the `phrosty` directory, run the following::
 
-  SNPIT_CONFIG=phrosty/tests/phrosty_test_config_smce.yaml python phrosty/pipeline.py \
+  SNPIT_CONFIG=phrosty/tests/phrosty_test_config_smdc.yaml python phrosty/pipeline.py \
         --oid 11 \
         -oc manual \
         -b Y106 \

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -473,7 +473,7 @@ Do all the installation stuff, and run phrosty::
         -t phrosty/tests/11_instances_templates_1.csv \
         -s phrosty/tests/11_instances_science_2.csv \
         -p 1 -w 1 \
-        -v
+        -v 
 
 
 Running on a HPC system that uses apptainer/singularity

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -378,6 +378,10 @@ Get yourself a GPU node. Do::
 
   salloc -p gpu-int --time=02:00:00
 
+Then, to avoid permissions issues, do::
+
+  ssh localhost
+
 Then, go into the Singularity container::
 
   sh environment/smdc-phrostydev-apptainer.sh 
@@ -447,6 +451,21 @@ The SNe Ia in the sims are object IDs `11` and `21`. We are going to test on `11
         -d -43.958825 \
         -ic manual_rdm \
         --base-path /rick/romanisim/ \
+        -t phrosty/tests/11_instances_templates_1.csv \
+        -s phrosty/tests/11_instances_science_2.csv \
+        -p 1 -w 1 \
+        -v
+
+On NERSC (NOTE: This is just for Lauren right now. They edited Rob's interactive podman to include a hook to `photometry_test_data`, and also put some Ricksims in that folder. They are trying to push it to github, but the large files are giving them issues. The interactive podman file is in `phrosty/phrosty/tests` right now.)::
+
+  SNPIT_CONFIG=phrosty/tests/phrosty_test_config.yaml python phrosty/pipeline.py \
+        --oid 11 \
+        -oc manual \
+        -b J129 \
+        -r 9.366435 \
+        -d -43.958825 \
+        -ic manual_rdm \
+        --base-path /photometry_test_data/ricksims/ \
         -t phrosty/tests/11_instances_templates_1.csv \
         -s phrosty/tests/11_instances_science_2.csv \
         -p 1 -w 1 \

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -458,6 +458,10 @@ The SNe Ia in the sims are object IDs `11` and `21`. We are going to test on `11
 
 On NERSC (NOTE: This is just for Lauren right now. They edited Rob's interactive podman to include a hook to `photometry_test_data`, and also put some Ricksims in that folder. They are trying to push it to github, but the large files are giving them issues. The interactive podman file is in `phrosty/phrosty/tests` right now.)::
 
+  WHICHROMANENV=cuda-dev bash phrosty/phrosty/tests/interactive-podman-rknop-dev-mod.sh
+
+Do all the installation stuff, and run phrosty::
+
   SNPIT_CONFIG=phrosty/tests/phrosty_test_config.yaml python phrosty/pipeline.py \
         --oid 11 \
         -oc manual \

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -353,11 +353,11 @@ and, ideally, there should be no lines anywhere in the file with ``ERROR`` near 
 
 Note that ``/lc_out_dir/...`` is the absolute path _inside_ the container; it maps to ``lc_out_dir/...`` underneath your working directory where you ran ``sbatch``.  You will find the lightcurve in that ``.pq`` file.  There will also be a number of files written to the ``dia_out_dir`` directory.
 
-Running on SMCE
+Running on SMDC
 ---------------
 If you are using this section, you are probably a member of the SN PIT. 
 
-General instructions for accessing SMCE can be found `in the wiki <https://github.com/Roman-Supernova-PIT/Roman-Supernova-PIT/wiki/NASA-SMDC-%28AWS%29>`_.
+General instructions for accessing SMDC can be found `in the wiki <https://github.com/Roman-Supernova-PIT/Roman-Supernova-PIT/wiki/NASA-SMDC-%28AWS%29>`_.
 
 First, follow the directions under `"Working with PIT Images" here <https://github.com/Roman-Supernova-PIT/Roman-Supernova-PIT/wiki/SMCE-Containers>`_.
 
@@ -418,6 +418,40 @@ If you run into permissions issues with writing to `scratch`, `dia_out_dir`, or 
   ssh localhost
 
 Then, type `groups`. You should see `[your username] spack cluster_users snpit`. If not, I can't help you. Now, you can go back into the container and try running phrosty again. 
+
+Using ASDF
+^^^^^^^^^^
+This section is currently for the SN PIT, and it is underneath "Running on SMDC" because the sims I am describing are located there.
+
+Right now, Rick's `romanisim` images are on SMDC at::
+  
+  /home/rkessler/romanisim/output_images_galid_force0
+  /home/rkessler/romanisim/output_images_galid_force1
+
+where `force0` indicates random magnitude light curves for two events far away from their hosts, and `force1` is the same light curves but near their host centers.
+
+Corresponding SNANA truth files are located at::
+
+  /home/rkessler/romanisim/snana_sim_galid_force0
+  /home/rkessler/romanisim/snana_sim_galid_force1
+
+If you are in the Singularity container discussed above, `/home/rkessler/` maps to `/rick`.
+
+The SNe Ia in the sims are object IDs `11` and `21`. We are going to test on `11`. Do all of the things above, and from the `phrosty` directory, run the following::
+
+  SNPIT_CONFIG=phrosty/tests/phrosty_test_config_smce.yaml python phrosty/pipeline.py \
+        --oid 11 \
+        -oc manual \
+        -b Y106 \
+        -r 9.366435 \
+        -d -43.958825 \
+        -ic manual_rdm \
+        --base-path /rick/romanisim/ \
+        -t phrosty/tests/11_instances_templates_1.csv \
+        -s phrosty/tests/11_instances_science_2.csv \
+        -p 1 -w 1 \
+        -v
+
 
 Running on a HPC system that uses apptainer/singularity
 -------------------------------------------------------
@@ -560,9 +594,6 @@ The column headers in the output ``pq`` files are:
 
 .. Running on arbitrary images
 .. ---------------------------
-
-.. Using ASDF
-.. ----------
 
 .. Using the A25 ePSFs
 .. -------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -378,7 +378,7 @@ Get yourself a GPU node. Do::
 
   salloc -p gpu-int --time=02:00:00
 
-You will likely have different permissions on the login node compared to the GPU node. If you type `groups` on the login node, you'll see `[your username] spack cluster_users snpit`. If you type `groups` on the GPU node, you'll see `[your username] nogroup`. To circumvent these permissions issues, do::
+Sometimes your correct set of groups won't be correctly populated on a compute node due to a race condition between populating the container and correctly configuring the active directory lookup. You will see a message about this when you get your node that says that the groups weren't loaded properly. Also, if you type `groups` on the login node, you'll see `[your username] spack cluster_users snpit`. If you type `groups` on the GPU node, you'll see `[your username] nogroup`. You will also hit a permissions issue running `phrosty` when it tries to write files outside your home directory. To start a new terminal that will have the groups loaded correctly, do::
 
   ssh localhost
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -378,7 +378,7 @@ Get yourself a GPU node. Do::
 
   salloc -p gpu-int --time=02:00:00
 
-Then, to avoid permissions issues, do::
+You will likely have different permissions on the login node compared to the GPU node. If you type `groups` on the login node, you'll see `[your username] spack cluster_users snpit`. If you type `groups` on the GPU node, you'll see `[your username] nogroup`. To circumvent these permissions issues, do::
 
   ssh localhost
 
@@ -416,12 +416,6 @@ Then, run phrosty::
         -s phrosty/tests/20172782_instances_science_2.csv \
         -p 3 -w 3 \
         -v
-
-If you run into permissions issues with writing to `scratch`, `dia_out_dir`, or `lc_out_dir`, type `groups`. It will probably say `[your username] nogroup`. If this is the case, exit the container and do::
-
-  ssh localhost
-
-Then, type `groups`. You should see `[your username] spack cluster_users snpit`. If not, I can't help you. Now, you can go back into the container and try running phrosty again. 
 
 Using ASDF
 ^^^^^^^^^^

--- a/phrosty/imagesubtraction.py
+++ b/phrosty/imagesubtraction.py
@@ -138,102 +138,6 @@ def sky_subtract( img, temp_dir=None,
 
     return subim, detmaskim, rms
 
-
-# def sky_subtract( img, temp_dir=None ):
-#     """Subtracts background, found with Source Extractor.
-
-#     Parameters
-#     ----------
-#       img: snappl.image.Image
-#         Original image.
-
-#       temp_dir: Path, default None
-#         Already-existing directory where we can write a temporary file.
-#         Defaults to photometry.snappl.temp_dir from the config.
-
-#     Returns
-#     -------
-#       skysubim: snappl.image.FITSImage, detmask: snappl.image.FITSImage, skyrms: float
-
-#          skysubim is the sky-subtracted image.  Its location on disk
-#          will be underneath temp_dir. It's the caller's responsibility
-#          to clean this up.  The file will have been written, so you
-#          can pass skysubim.path to any thing that needs the path of a
-#          single-HDU FITS image.
-
-#          detmask is the detection mask.  Its location on disk will be
-#          underneath temp_dir.  It's the caller's responsibility to clean
-#          this up.  The file will have been written, so you can pass
-#          detmask.path to any thing that needs the path of a single-HDU
-#          FITS image.
-
-#          skyrms is the median of the skyrms image calculated by source-extractor
-
-#     """
-
-#     # SEx_SkySubtract.SSS requires FITS files to chew on.  At some point
-#     # we should refactor this so that we can pass data to it.  However,
-#     # for now, write a snappl.image.FITSImage so we have something
-#     # to give to it.
-
-#     temp_dir = pathlib.Path( temp_dir if temp_dir is not None else Config.get().value( 'photometry.snappl.temp_dir' ) )
-#     barf = "".join( random.choices( "0123456789abcdef", k=10 ) )
-#     tmpfitspath = temp_dir / f"{barf}_fits_from_asdf.fits"
-#     tmpimpath = temp_dir / f"{barf}_sub.fits"
-#     tmpsubpath = temp_dir / f"{barf}_sub.fits"
-#     tmpdetmaskpath = temp_dir / f"{barf}_detmask.fits"
-
-#     origimg = img
-#     if isinstance( origimg, snappl.image.CompressedFITSImage ):
-#         img = origimg.uncompressed_version( include=['data'] )
-#     elif isinstance( origimg, snappl.image.RomanDatamodelImage ):
-#         # The next few lines that make the header are stolen from sidecar.
-#         hdr = origimg.get_wcs().get_astropy_wcs().to_header(relax=True)
-#         hdr.insert(0, ("NAXIS", 2))
-#         hdr.insert("NAXIS", ("NAXIS1", img.data.shape[1]), after=True)
-#         hdr.insert("NAXIS1", ("NAXIS2", img.data.shape[0]), after=True)
-#         img = snappl.image.FITSImage( 
-#                                       full_filepath=tmpfitspath,
-#                                       data=origimg.get_data(which='data')[0],
-#                                       header=hdr
-#                                     )
-#         img.save()
-#     else:
-#         # TODO, MAYBE MAKE THIS BETTER WHEN SNAPPL SUPPORTS MORE THINGS
-#         # We need to exract just the image data (not the noise or flags)
-#         # to send to image subtraction.
-#         # Lauren, make an issue about this, mauybe also a snappl image
-#         # that says that we need a way of making imgaes from other
-#         # images including only data... compressedfitsimage supports
-#         # that right now but not fitsimage).
-#         # Can take out header arg when snappl issue #77 is resolved.
-#         img = snappl.image.FITSImage( path=tmpimpath, header=fits.header.Header() )
-#         img.data = origimg.data
-#         img.save( which='data' )
-
-#     SNLogger.debug( "Calling SEx_SkySubtract.SSS..." )
-#     radius_cut_detmask = Config.get().value( 'photometry.phrosty.sfft.radius_cut_detmask' )
-#     import pdb; pdb.set_trace()
-#     ( _SKYDIP, _SKYPEAK, _PixA_skysub,
-#       _PixA_sky, PixA_skyrms ) = SEx_SkySubtract.SSS( FITS_obj=img.path,
-#                                                       FITS_skysub=tmpsubpath,
-#                                                       FITS_detmask=tmpdetmaskpath,
-#                                                       FITS_sky=None, FITS_skyrms=None,
-#                                                       ESATUR_KEY='ESATUR',
-#                                                       BACK_SIZE=64, BACK_FILTERSIZE=3,
-#                                                       DETECT_THRESH=1.5, DETECT_MINAREA=5,
-#                                                       DETECT_MAXAREA=0,
-#                                                       RADIUS_CUT_DETMASK=radius_cut_detmask,
-#                                                       VERBOSE_LEVEL=2, MDIR=None )
-
-
-#     SNLogger.debug( "...back from SEx_SkySubtract.SSS" )
-
-#     subim = snappl.image.FITSImage( path=tmpsubpath )
-#     detmaskim = snappl.image.FITSImage( path=tmpdetmaskpath )
-#     skyrms = np.median( PixA_skyrms )
-#     return subim, detmaskim, skyrms
-
 def stampmaker(ra, dec, shape, img, savedir=None, savename=None, data_prop='data'):
     """Make stamps.
 
@@ -283,21 +187,41 @@ def stampmaker(ra, dec, shape, img, savedir=None, savename=None, data_prop='data
     pxradec = np.array([[x, y]])
 
     # Give Stamp_Generator.SG a FITS image to chew on
+    barf = "".join( random.choices( "0123456789abcdef", k=10 ) )
+    tmpfitspath = savedir / f"{barf}.fits"
     origimg = img
     try:
-        # if isinstance( origimg, snappl.image.CompressedFITSImage ):
-        #     img = origimg.uncompressed_version( include=[ext_type] )
-        # else:
-        barf = "".join( random.choices( "0123456789abcdef", k=10 ) )
-        # NOTE : this next line will break if not using an image type that
-        #   can return a FITS header!  The real solution is to fix SFFT
-        #   so that it's not dependent on FITS images; just pass what's
-        #   needed to Stamp_Generator.SG instead of assuming it will read
-        #   all the right things out of the header.
-        # See issue 177: https://github.com/Roman-Supernova-PIT/phrosty/issues/177
-        img = snappl.image.FITSImage( path=savedir / f"{barf}.fits", header=origimg.get_fits_header() )
-        img.data = getattr(origimg, data_prop)
-        img.save_data( which='data' )
+        if isinstance( origimg, snappl.image.CompressedFITSImage ):
+            img = origimg.uncompressed_version( include=[data_prop] )
+        elif isinstance( origimg, snappl.image.RomanDatamodelImage ):
+            # The next few lines that make the header are stolen from sidecar.
+            hdr = origimg.get_wcs().get_astropy_wcs().to_header(relax=True)
+            hdr.insert(0, ("NAXIS", 2))
+            hdr.insert("NAXIS", ("NAXIS1", img.data.shape[1]), after=True)
+            hdr.insert("NAXIS1", ("NAXIS2", img.data.shape[0]), after=True)
+            img = snappl.image.FITSImage( 
+                                          full_filepath=tmpfitspath,
+                                          data=origimg.get_data(which='data')[0],
+                                          header=hdr
+                                        )
+            img.save()
+
+        else:
+          # NOTE : this next line will break if not using an image type that
+          #   can return a FITS header!  The real solution is to fix SFFT
+          #   so that it's not dependent on FITS images; just pass what's
+          #   needed to Stamp_Generator.SG instead of assuming it will read
+          #   all the right things out of the header.
+          # See issue 177: https://github.com/Roman-Supernova-PIT/phrosty/issues/177
+            img = snappl.image.FITSImage( path=savedir / f"{barf}.fits", header=origimg.get_fits_header() )
+       
+        if isinstance( origimg, snappl.image.RomanDatamodelImage ):
+            img.data = origimg.get_data(which='data')[0]
+            img.save_data( which='data', overwrite=True )
+        else:  
+            import pdb; pdb.set_trace()
+            img.data = getattr(origimg, data_prop)
+            img.save_data( which='data', overwrite=True )
 
         # TODO : if Stamp_Generator.SG can take a Path in FITS_StpLst, remove the str()
         Stamp_Generator.SG(FITS_obj=img.path, COORD=pxradec, COORD_TYPE='IMAGE',

--- a/phrosty/imagesubtraction.py
+++ b/phrosty/imagesubtraction.py
@@ -10,6 +10,8 @@ from photutils.segmentation import detect_threshold, detect_sources
 from photutils.utils import circular_footprint
 import random
 from scipy.signal import convolve2d
+from scipy.interpolate import griddata
+from roman_datamodels import dqflags
 
 # IMPORTS SFFT:
 from sfft.utils.SExSkySubtract import SEx_SkySubtract
@@ -19,6 +21,55 @@ from sfft.utils.StampGenerator import Stamp_Generator
 from snappl.config import Config
 import snappl.image
 from snappl.logger import SNLogger
+
+def interpolate_over_bad_pixels(data, dataflags, fill_value=0):
+    """Interpolate over bad pixels in an image.
+
+    NOTE: This is stolen from sidecar, and is written by WMWV. Lauren modified it.
+    Parameters
+    ----------
+    data : ndarray
+        Input data array.
+    dataflags : ndarray
+        Input flags array.
+    bad_pixel_flags : int, optional
+        Bitwise combination of DQ flags used to identify bad pixels.
+    fill_value : float, optional
+        Value to use for filling bad pixels if interpolation is not possible. Default is 0.
+
+    Returns
+    -------
+    interpolated_data : ndarray
+        The input image data with bad pixels interpolated over.
+
+    bad_pixel_mask : ndarray
+        Boolean mask indicating the locations of bad pixels that were interpolated over.
+
+    Notes
+    -----
+    This function identifies bad pixels based on the provided `bad_pixel_flags`
+    and performs interpolation to fill in those pixels.
+    The interpolation method can be simple (e.g., nearest neighbor) or more sophisticated
+    (e.g., using neighboring pixel values), depending on the implementation.
+    """
+    # Create a mask of bad pixels based on the flags
+    bad_pixel_flags = 2 ** len(dqflags.pixel) - 1 - dqflags.pixel.WARM - dqflags.pixel.LOW_QE
+    # bad_mask = dataflags & bad_pixel_flags > 0
+    # bad_mask = dataflags
+    bad_mask = np.isnan(data)
+    good_pixels = ~np.isnan(data)
+
+    interpolated_data = data.copy()
+    interpolated_data[bad_mask] = np.nan  # Mark bad pixels as NaN for interpolation
+
+    # Example interpolation using nearest neighbor
+    x, y = np.indices(data.shape)
+    # good_pixels = ~bad_mask
+    interpolated_data[bad_mask] = griddata(
+        (x[good_pixels], y[good_pixels]), data[good_pixels], (x[bad_mask], y[bad_mask]), method="nearest"
+    )
+
+    return interpolated_data, bad_mask
 
 def sky_subtract( img, temp_dir=None,
                   nonlinear_threshold=1000,
@@ -60,7 +111,6 @@ def sky_subtract( img, temp_dir=None,
     # we should refactor this so that we can pass data to it.  However,
     # for now, write a snappl.image.FITSImage so we have something
     # to give to it.
-
     temp_dir = pathlib.Path( temp_dir if temp_dir is not None else Config.get().value( 'photometry.snappl.temp_dir' ) )
     barf = "".join( random.choices( "0123456789abcdef", k=10 ) )
     tmpfitspath = temp_dir / f"{barf}_fits_from_asdf.fits"
@@ -97,12 +147,16 @@ def sky_subtract( img, temp_dir=None,
         hdr = img.get_fits_header()
         img.save( which='data' )
 
+    SNLogger.debug( "Interpolate over bad pixels...")
+    # NOTE: Make interp_mask do something at a later time.
+    interp_data, _ = interpolate_over_bad_pixels(img.data, origimg.flags)
+
     SNLogger.debug( "Beginning sky subtraction..." )
     radius_cut_detmask = Config.get().value( 'photometry.phrosty.sfft.radius_cut_detmask' )
 
-    bkg = Background2D(img.data, box_size=64)
+    bkg = Background2D(interp_data, box_size=64)
 
-    sky_subtracted_data = img.data - bkg.background
+    sky_subtracted_data = interp_data - bkg.background
     rms = bkg.background_rms_median
 
     # Based on the photutils.background documentation

--- a/phrosty/imagesubtraction.py
+++ b/phrosty/imagesubtraction.py
@@ -67,10 +67,10 @@ def sky_subtract( img, temp_dir=None,
     tmpimpath = temp_dir / f"{barf}_sub.fits"
     tmpsubpath = temp_dir / f"{barf}_sub.fits"
     tmpdetmaskpath = temp_dir / f"{barf}_detmask.fits"
-
     origimg = img
     if isinstance( origimg, snappl.image.CompressedFITSImage ):
         img = origimg.uncompressed_version( include=['data'] )
+        hdr = img.get_fits_header()
     elif isinstance( origimg, snappl.image.RomanDatamodelImage ):
         # The next few lines that make the header are stolen from sidecar.
         hdr = origimg.get_wcs().get_astropy_wcs().to_header(relax=True)
@@ -94,6 +94,7 @@ def sky_subtract( img, temp_dir=None,
         # Can take out header arg when snappl issue #77 is resolved.
         img = snappl.image.FITSImage( path=tmpimpath, header=fits.header.Header() )
         img.data = origimg.data
+        hdr = img.get_fits_header()
         img.save( which='data' )
 
     SNLogger.debug( "Beginning sky subtraction..." )

--- a/phrosty/imagesubtraction.py
+++ b/phrosty/imagesubtraction.py
@@ -62,6 +62,8 @@ def sky_subtract( img, temp_dir=None ):
     origimg = img
     if isinstance( origimg, snappl.image.CompressedFITSImage ):
         img = origimg.uncompressed_version( include=['data'] )
+    elif isinstance( origimg, snappl.image.RomanDatamodelImage ):
+        img = origimg.data
     else:
         # TODO, MAYBE MAKE THIS BETTER WHEN SNAPPL SUPPORTS MORE THINGS
         # We need to exract just the image data (not the noise or flags)

--- a/phrosty/imagesubtraction.py
+++ b/phrosty/imagesubtraction.py
@@ -106,7 +106,7 @@ def sky_subtract( img, temp_dir=None,
 
     # Based on the photutils.background documentation
     sigma_clip = SigmaClip(sigma=2.0, maxiters=10)
-    threshold = detect_threshold(sky_subtracted_data, nsigma=20.0, sigma_clip=sigma_clip)
+    threshold = detect_threshold(sky_subtracted_data, n_sigma=20.0, sigma_clip=sigma_clip)
 
     # Build a mask of pixels that are in the non-linear retime
     mask = np.abs(sky_subtracted_data) > nonlinear_threshold
@@ -114,7 +114,7 @@ def sky_subtract( img, temp_dir=None,
     mask_footprint = circular_footprint(radius=mask_radius)
     mask = convolve2d(mask, mask_footprint, fillvalue=0, mode="same")
 
-    segment_img = detect_sources(sky_subtracted_data, threshold, npixels=10, mask=mask)
+    segment_img = detect_sources(sky_subtracted_data, threshold, n_pixels=10, mask=mask)
     detection_footprint = circular_footprint(radius=10)
 
     # convert boolean into float 1, and 0 because data must be float (not bool or int).
@@ -214,14 +214,8 @@ def stampmaker(ra, dec, shape, img, savedir=None, savename=None, data_prop='data
           #   all the right things out of the header.
           # See issue 177: https://github.com/Roman-Supernova-PIT/phrosty/issues/177
             img = snappl.image.FITSImage( path=savedir / f"{barf}.fits", header=origimg.get_fits_header() )
-       
-        if isinstance( origimg, snappl.image.RomanDatamodelImage ):
-            img.data = origimg.get_data(which='data')[0]
-            img.save_data( which='data', overwrite=True )
-        else:  
-            import pdb; pdb.set_trace()
-            img.data = getattr(origimg, data_prop)
-            img.save_data( which='data', overwrite=True )
+            img.data = origimg.data
+            img.save( which='data' )
 
         # TODO : if Stamp_Generator.SG can take a Path in FITS_StpLst, remove the str()
         Stamp_Generator.SG(FITS_obj=img.path, COORD=pxradec, COORD_TYPE='IMAGE',

--- a/phrosty/imagesubtraction.py
+++ b/phrosty/imagesubtraction.py
@@ -54,17 +54,14 @@ def interpolate_over_bad_pixels(data, dataflags, fill_value=0):
     """
     # Create a mask of bad pixels based on the flags
     bad_pixel_flags = 2 ** len(dqflags.pixel) - 1 - dqflags.pixel.WARM - dqflags.pixel.LOW_QE
-    # bad_mask = dataflags & bad_pixel_flags > 0
-    # bad_mask = dataflags
-    bad_mask = np.isnan(data)
-    good_pixels = ~np.isnan(data)
+    bad_mask = np.isnan(data) | (dataflags & bad_pixel_flags > 0)
+    good_pixels = ~bad_mask
 
     interpolated_data = data.copy()
     interpolated_data[bad_mask] = np.nan  # Mark bad pixels as NaN for interpolation
 
     # Example interpolation using nearest neighbor
     x, y = np.indices(data.shape)
-    # good_pixels = ~bad_mask
     interpolated_data[bad_mask] = griddata(
         (x[good_pixels], y[good_pixels]), data[good_pixels], (x[bad_mask], y[bad_mask]), method="nearest"
     )

--- a/phrosty/imagesubtraction.py
+++ b/phrosty/imagesubtraction.py
@@ -14,13 +14,13 @@ from scipy.interpolate import griddata
 from roman_datamodels import dqflags
 
 # IMPORTS SFFT:
-from sfft.utils.SExSkySubtract import SEx_SkySubtract
 from sfft.utils.StampGenerator import Stamp_Generator
 
 # IMPORTS internal
 from snappl.config import Config
 import snappl.image
 from snappl.logger import SNLogger
+
 
 def interpolate_over_bad_pixels(data, dataflags, fill_value=0):
     """Interpolate over bad pixels in an image.
@@ -67,6 +67,7 @@ def interpolate_over_bad_pixels(data, dataflags, fill_value=0):
     )
 
     return interpolated_data, bad_mask
+
 
 def sky_subtract( img, temp_dir=None,
                   nonlinear_threshold=1000,
@@ -124,7 +125,7 @@ def sky_subtract( img, temp_dir=None,
         hdr.insert(0, ("NAXIS", 2))
         hdr.insert("NAXIS", ("NAXIS1", img.data.shape[1]), after=True)
         hdr.insert("NAXIS1", ("NAXIS2", img.data.shape[0]), after=True)
-        img = snappl.image.FITSImage( 
+        img = snappl.image.FITSImage(
                                       full_filepath=tmpfitspath,
                                       data=origimg.get_data(which='data')[0],
                                       header=hdr
@@ -149,7 +150,9 @@ def sky_subtract( img, temp_dir=None,
     interp_data, _ = interpolate_over_bad_pixels(img.data, origimg.flags)
 
     SNLogger.debug( "Beginning sky subtraction..." )
-    radius_cut_detmask = Config.get().value( 'photometry.phrosty.sfft.radius_cut_detmask' )
+    # We should talk about where radius_cut_detmask should go now that I have gotten
+    # rid of Source Extractor.
+    # radius_cut_detmask = Config.get().value( 'photometry.phrosty.sfft.radius_cut_detmask' )
 
     bkg = Background2D(interp_data, box_size=64)
 
@@ -174,7 +177,7 @@ def sky_subtract( img, temp_dir=None,
 
     SNLogger.debug( "...back from sky subtraction." )
 
-    subim = snappl.image.FITSImage( 
+    subim = snappl.image.FITSImage(
                                     full_filepath=tmpsubpath,
                                     data=sky_subtracted_data,
                                     header=hdr
@@ -189,6 +192,7 @@ def sky_subtract( img, temp_dir=None,
     detmaskim.save()
 
     return subim, detmaskim, rms
+
 
 def stampmaker(ra, dec, shape, img, savedir=None, savename=None, data_prop='data'):
     """Make stamps.
@@ -251,7 +255,7 @@ def stampmaker(ra, dec, shape, img, savedir=None, savename=None, data_prop='data
             hdr.insert(0, ("NAXIS", 2))
             hdr.insert("NAXIS", ("NAXIS1", img.data.shape[1]), after=True)
             hdr.insert("NAXIS1", ("NAXIS2", img.data.shape[0]), after=True)
-            img = snappl.image.FITSImage( 
+            img = snappl.image.FITSImage(
                                           full_filepath=tmpfitspath,
                                           data=origimg.get_data(which='data')[0],
                                           header=hdr

--- a/phrosty/imagesubtraction.py
+++ b/phrosty/imagesubtraction.py
@@ -74,7 +74,7 @@ def sky_subtract( img, temp_dir=None,
                   footprint_radius=10,
                   mask_radius=5,
                   **kwargs ):
-    """Subtracts background, found with Source Extractor.
+    """Subtracts background using photutils.
 
     Parameters
     ----------

--- a/phrosty/imagesubtraction.py
+++ b/phrosty/imagesubtraction.py
@@ -2,9 +2,14 @@ __all__ = [ 'sky_subtract', 'stampmaker' ]
 
 # IMPORTS Standard:
 from astropy.io import fits
+from astropy.stats import SigmaClip
 import numpy as np
 import pathlib
+from photutils.background import Background2D
+from photutils.segmentation import detect_threshold, detect_sources
+from photutils.utils import circular_footprint
 import random
+from scipy.signal import convolve2d
 
 # IMPORTS SFFT:
 from sfft.utils.SExSkySubtract import SEx_SkySubtract
@@ -15,8 +20,11 @@ from snappl.config import Config
 import snappl.image
 from snappl.logger import SNLogger
 
-
-def sky_subtract( img, temp_dir=None ):
+def sky_subtract( img, temp_dir=None,
+                  nonlinear_threshold=1000,
+                  footprint_radius=10,
+                  mask_radius=5,
+                  **kwargs ):
     """Subtracts background, found with Source Extractor.
 
     Parameters
@@ -55,6 +63,7 @@ def sky_subtract( img, temp_dir=None ):
 
     temp_dir = pathlib.Path( temp_dir if temp_dir is not None else Config.get().value( 'photometry.snappl.temp_dir' ) )
     barf = "".join( random.choices( "0123456789abcdef", k=10 ) )
+    tmpfitspath = temp_dir / f"{barf}_fits_from_asdf.fits"
     tmpimpath = temp_dir / f"{barf}_sub.fits"
     tmpsubpath = temp_dir / f"{barf}_sub.fits"
     tmpdetmaskpath = temp_dir / f"{barf}_detmask.fits"
@@ -63,7 +72,17 @@ def sky_subtract( img, temp_dir=None ):
     if isinstance( origimg, snappl.image.CompressedFITSImage ):
         img = origimg.uncompressed_version( include=['data'] )
     elif isinstance( origimg, snappl.image.RomanDatamodelImage ):
-        img = origimg.data
+        # The next few lines that make the header are stolen from sidecar.
+        hdr = origimg.get_wcs().get_astropy_wcs().to_header(relax=True)
+        hdr.insert(0, ("NAXIS", 2))
+        hdr.insert("NAXIS", ("NAXIS1", img.data.shape[1]), after=True)
+        hdr.insert("NAXIS1", ("NAXIS2", img.data.shape[0]), after=True)
+        img = snappl.image.FITSImage( 
+                                      full_filepath=tmpfitspath,
+                                      data=origimg.get_data(which='data')[0],
+                                      header=hdr
+                                    )
+        img.save()
     else:
         # TODO, MAYBE MAKE THIS BETTER WHEN SNAPPL SUPPORTS MORE THINGS
         # We need to exract just the image data (not the noise or flags)
@@ -75,30 +94,145 @@ def sky_subtract( img, temp_dir=None ):
         # Can take out header arg when snappl issue #77 is resolved.
         img = snappl.image.FITSImage( path=tmpimpath, header=fits.header.Header() )
         img.data = origimg.data
-        img.save_data( which='data' )
+        img.save( which='data' )
 
-    SNLogger.debug( "Calling SEx_SkySubtract.SSS..." )
+    SNLogger.debug( "Beginning sky subtraction..." )
     radius_cut_detmask = Config.get().value( 'photometry.phrosty.sfft.radius_cut_detmask' )
-    ( _SKYDIP, _SKYPEAK, _PixA_skysub,
-      _PixA_sky, PixA_skyrms ) = SEx_SkySubtract.SSS(FITS_obj=img.path,
-                                                      FITS_skysub=tmpsubpath,
-                                                      FITS_detmask=tmpdetmaskpath,
-                                                      FITS_sky=None, FITS_skyrms=None,
-                                                      ESATUR_KEY='ESATUR',
-                                                      BACK_SIZE=64, BACK_FILTERSIZE=3,
-                                                      DETECT_THRESH=1.5, DETECT_MINAREA=5,
-                                                      DETECT_MAXAREA=0,
-                                                      RADIUS_CUT_DETMASK=radius_cut_detmask,
-                                                      VERBOSE_LEVEL=2, MDIR=None)
+
+    bkg = Background2D(img.data, box_size=64)
+
+    sky_subtracted_data = img.data - bkg.background
+    rms = bkg.background_rms_median
+
+    # Based on the photutils.background documentation
+    sigma_clip = SigmaClip(sigma=2.0, maxiters=10)
+    threshold = detect_threshold(sky_subtracted_data, nsigma=20.0, sigma_clip=sigma_clip)
+
+    # Build a mask of pixels that are in the non-linear retime
+    mask = np.abs(sky_subtracted_data) > nonlinear_threshold
+    # Grow individual pixels by mask_radius
+    mask_footprint = circular_footprint(radius=mask_radius)
+    mask = convolve2d(mask, mask_footprint, fillvalue=0, mode="same")
+
+    segment_img = detect_sources(sky_subtracted_data, threshold, npixels=10, mask=mask)
+    detection_footprint = circular_footprint(radius=10)
+
+    # convert boolean into float 1, and 0 because data must be float (not bool or int).
+    detmask_data = np.asarray(segment_img.make_source_mask(footprint=detection_footprint), dtype="float")
+
+    SNLogger.debug( "...back from sky subtraction." )
+
+    subim = snappl.image.FITSImage( 
+                                    full_filepath=tmpsubpath,
+                                    data=sky_subtracted_data,
+                                    header=hdr
+                                  )
+    subim.save()
+
+    detmaskim = snappl.image.FITSImage(
+                                        full_filepath=tmpdetmaskpath,
+                                        data=detmask_data,
+                                        header=hdr
+                                      )
+    detmaskim.save()
+
+    return subim, detmaskim, rms
 
 
-    SNLogger.debug( "...back from SEx_SkySubtract.SSS" )
+# def sky_subtract( img, temp_dir=None ):
+#     """Subtracts background, found with Source Extractor.
 
-    subim = snappl.image.FITSImage( path=tmpsubpath )
-    detmaskim = snappl.image.FITSImage( path=tmpdetmaskpath )
-    skyrms = np.median( PixA_skyrms )
-    return subim, detmaskim, skyrms
+#     Parameters
+#     ----------
+#       img: snappl.image.Image
+#         Original image.
 
+#       temp_dir: Path, default None
+#         Already-existing directory where we can write a temporary file.
+#         Defaults to photometry.snappl.temp_dir from the config.
+
+#     Returns
+#     -------
+#       skysubim: snappl.image.FITSImage, detmask: snappl.image.FITSImage, skyrms: float
+
+#          skysubim is the sky-subtracted image.  Its location on disk
+#          will be underneath temp_dir. It's the caller's responsibility
+#          to clean this up.  The file will have been written, so you
+#          can pass skysubim.path to any thing that needs the path of a
+#          single-HDU FITS image.
+
+#          detmask is the detection mask.  Its location on disk will be
+#          underneath temp_dir.  It's the caller's responsibility to clean
+#          this up.  The file will have been written, so you can pass
+#          detmask.path to any thing that needs the path of a single-HDU
+#          FITS image.
+
+#          skyrms is the median of the skyrms image calculated by source-extractor
+
+#     """
+
+#     # SEx_SkySubtract.SSS requires FITS files to chew on.  At some point
+#     # we should refactor this so that we can pass data to it.  However,
+#     # for now, write a snappl.image.FITSImage so we have something
+#     # to give to it.
+
+#     temp_dir = pathlib.Path( temp_dir if temp_dir is not None else Config.get().value( 'photometry.snappl.temp_dir' ) )
+#     barf = "".join( random.choices( "0123456789abcdef", k=10 ) )
+#     tmpfitspath = temp_dir / f"{barf}_fits_from_asdf.fits"
+#     tmpimpath = temp_dir / f"{barf}_sub.fits"
+#     tmpsubpath = temp_dir / f"{barf}_sub.fits"
+#     tmpdetmaskpath = temp_dir / f"{barf}_detmask.fits"
+
+#     origimg = img
+#     if isinstance( origimg, snappl.image.CompressedFITSImage ):
+#         img = origimg.uncompressed_version( include=['data'] )
+#     elif isinstance( origimg, snappl.image.RomanDatamodelImage ):
+#         # The next few lines that make the header are stolen from sidecar.
+#         hdr = origimg.get_wcs().get_astropy_wcs().to_header(relax=True)
+#         hdr.insert(0, ("NAXIS", 2))
+#         hdr.insert("NAXIS", ("NAXIS1", img.data.shape[1]), after=True)
+#         hdr.insert("NAXIS1", ("NAXIS2", img.data.shape[0]), after=True)
+#         img = snappl.image.FITSImage( 
+#                                       full_filepath=tmpfitspath,
+#                                       data=origimg.get_data(which='data')[0],
+#                                       header=hdr
+#                                     )
+#         img.save()
+#     else:
+#         # TODO, MAYBE MAKE THIS BETTER WHEN SNAPPL SUPPORTS MORE THINGS
+#         # We need to exract just the image data (not the noise or flags)
+#         # to send to image subtraction.
+#         # Lauren, make an issue about this, mauybe also a snappl image
+#         # that says that we need a way of making imgaes from other
+#         # images including only data... compressedfitsimage supports
+#         # that right now but not fitsimage).
+#         # Can take out header arg when snappl issue #77 is resolved.
+#         img = snappl.image.FITSImage( path=tmpimpath, header=fits.header.Header() )
+#         img.data = origimg.data
+#         img.save( which='data' )
+
+#     SNLogger.debug( "Calling SEx_SkySubtract.SSS..." )
+#     radius_cut_detmask = Config.get().value( 'photometry.phrosty.sfft.radius_cut_detmask' )
+#     import pdb; pdb.set_trace()
+#     ( _SKYDIP, _SKYPEAK, _PixA_skysub,
+#       _PixA_sky, PixA_skyrms ) = SEx_SkySubtract.SSS( FITS_obj=img.path,
+#                                                       FITS_skysub=tmpsubpath,
+#                                                       FITS_detmask=tmpdetmaskpath,
+#                                                       FITS_sky=None, FITS_skyrms=None,
+#                                                       ESATUR_KEY='ESATUR',
+#                                                       BACK_SIZE=64, BACK_FILTERSIZE=3,
+#                                                       DETECT_THRESH=1.5, DETECT_MINAREA=5,
+#                                                       DETECT_MAXAREA=0,
+#                                                       RADIUS_CUT_DETMASK=radius_cut_detmask,
+#                                                       VERBOSE_LEVEL=2, MDIR=None )
+
+
+#     SNLogger.debug( "...back from SEx_SkySubtract.SSS" )
+
+#     subim = snappl.image.FITSImage( path=tmpsubpath )
+#     detmaskim = snappl.image.FITSImage( path=tmpdetmaskpath )
+#     skyrms = np.median( PixA_skyrms )
+#     return subim, detmaskim, skyrms
 
 def stampmaker(ra, dec, shape, img, savedir=None, savename=None, data_prop='data'):
     """Make stamps.

--- a/phrosty/imagesubtraction.py
+++ b/phrosty/imagesubtraction.py
@@ -22,7 +22,7 @@ import snappl.image
 from snappl.logger import SNLogger
 
 
-def interpolate_over_bad_pixels(data, dataflags, fill_value=0):
+def interpolate_over_bad_pixels(data, dataflags):
     """Interpolate over bad pixels in an image.
 
     NOTE: This is stolen from sidecar, and is written by WMWV. Lauren modified it.
@@ -34,8 +34,6 @@ def interpolate_over_bad_pixels(data, dataflags, fill_value=0):
         Input flags array.
     bad_pixel_flags : int, optional
         Bitwise combination of DQ flags used to identify bad pixels.
-    fill_value : float, optional
-        Value to use for filling bad pixels if interpolation is not possible. Default is 0.
 
     Returns
     -------
@@ -109,7 +107,7 @@ def sky_subtract( img, temp_dir=None,
     # we should refactor this so that we can pass data to it.  However,
     # for now, write a snappl.image.FITSImage so we have something
     # to give to it.
-    temp_dir = pathlib.Path( temp_dir if temp_dir is not None else Config.get().value( 'photometry.snappl.temp_dir' ) )
+    temp_dir = pathlib.Path( temp_dir if temp_dir is not None else Config.get().value( "photometry.snappl.temp_dir" ) )
     barf = "".join( random.choices( "0123456789abcdef", k=10 ) )
     tmpfitspath = temp_dir / f"{barf}_fits_from_asdf.fits"
     tmpimpath = temp_dir / f"{barf}_sub.fits"
@@ -117,7 +115,7 @@ def sky_subtract( img, temp_dir=None,
     tmpdetmaskpath = temp_dir / f"{barf}_detmask.fits"
     origimg = img
     if isinstance( origimg, snappl.image.CompressedFITSImage ):
-        img = origimg.uncompressed_version( include=['data'] )
+        img = origimg.uncompressed_version( include=["data"] )
         hdr = img.get_fits_header()
     elif isinstance( origimg, snappl.image.RomanDatamodelImage ):
         # The next few lines that make the header are stolen from sidecar.
@@ -127,13 +125,13 @@ def sky_subtract( img, temp_dir=None,
         hdr.insert("NAXIS1", ("NAXIS2", img.data.shape[0]), after=True)
         img = snappl.image.FITSImage(
                                       full_filepath=tmpfitspath,
-                                      data=origimg.get_data(which='data')[0],
+                                      data=origimg.get_data(which="data")[0],
                                       header=hdr
                                     )
         img.save()
     else:
         # TODO, MAYBE MAKE THIS BETTER WHEN SNAPPL SUPPORTS MORE THINGS
-        # We need to exract just the image data (not the noise or flags)
+        # We need to extract just the image data (not the noise or flags)
         # to send to image subtraction.
         # Lauren, make an issue about this, mauybe also a snappl image
         # that says that we need a way of making imgaes from other
@@ -143,7 +141,7 @@ def sky_subtract( img, temp_dir=None,
         img = snappl.image.FITSImage( path=tmpimpath, header=fits.header.Header() )
         img.data = origimg.data
         hdr = img.get_fits_header()
-        img.save( which='data' )
+        img.save( which="data" )
 
     SNLogger.debug( "Interpolate over bad pixels...")
     # NOTE: Make interp_mask do something at a later time.
@@ -163,7 +161,7 @@ def sky_subtract( img, temp_dir=None,
     sigma_clip = SigmaClip(sigma=2.0, maxiters=10)
     threshold = detect_threshold(sky_subtracted_data, n_sigma=20.0, sigma_clip=sigma_clip)
 
-    # Build a mask of pixels that are in the non-linear retime
+    # Build a mask of pixels that are in the non-linear regime
     mask = np.abs(sky_subtracted_data) > nonlinear_threshold
     # Grow individual pixels by mask_radius
     mask_footprint = circular_footprint(radius=mask_radius)
@@ -194,7 +192,7 @@ def sky_subtract( img, temp_dir=None,
     return subim, detmaskim, rms
 
 
-def stampmaker(ra, dec, shape, img, savedir=None, savename=None, data_prop='data'):
+def stampmaker(ra, dec, shape, img, savedir=None, savename=None, data_prop="data"):
     """Make stamps.
 
     TODO : pass an array of ra and dec to make this more efficient;
@@ -232,7 +230,7 @@ def stampmaker(ra, dec, shape, img, savedir=None, savename=None, data_prop='data
 
     if savedir is None:
         cfg = Config.get()
-        savedir = pathlib.Path( cfg.value( 'photometry.phrosty.paths.dia_out_dir' ) ) / "stamps"
+        savedir = pathlib.Path( cfg.value( "photometry.phrosty.paths.dia_out_dir" ) ) / "stamps"
     else:
         savedir = pathlib.Path( savedir )
     savedir.mkdir( parents=True, exist_ok=True )
@@ -271,10 +269,10 @@ def stampmaker(ra, dec, shape, img, savedir=None, savename=None, data_prop='data
           # See issue 177: https://github.com/Roman-Supernova-PIT/phrosty/issues/177
             img = snappl.image.FITSImage( path=savedir / f"{barf}.fits", header=origimg.get_fits_header() )
             img.data = origimg.data
-            img.save( which='data' )
+            img.save( which="data" )
 
         # TODO : if Stamp_Generator.SG can take a Path in FITS_StpLst, remove the str()
-        Stamp_Generator.SG(FITS_obj=img.path, COORD=pxradec, COORD_TYPE='IMAGE',
+        Stamp_Generator.SG(FITS_obj=img.path, COORD=pxradec, COORD_TYPE="IMAGE",
                            STAMP_IMGSIZE=shape, FILL_VALUE=np.nan, FITS_StpLst=str(savepath))
 
         return savepath

--- a/phrosty/pipeline.py
+++ b/phrosty/pipeline.py
@@ -385,12 +385,15 @@ class Pipeline:
             for line in ifp:
                 path, observation_id, sca, _mjd, band = line.split()
                 if band == self.band:
-                    # This should yell at us if the observation_id
-                    # or sca doesn't match what is read from the path
-                    imlist.append( self.imgcol.get_image( path=path,
-                                                          observation_id=observation_id,
-                                                          sca=sca,
-                                                          band=band ) )
+                    try:
+                        # This should yell at us if the observation_id
+                        # or sca doesn't match what is read from the path
+                        imlist.append( self.imgcol.get_image( path=path,
+                                                              observation_id=observation_id,
+                                                              sca=sca,
+                                                              band=band ) )
+                    except:
+                        imlist.append( self.imgcol.get_image( path=path ))
         return imlist
 
 

--- a/phrosty/pipeline.py
+++ b/phrosty/pipeline.py
@@ -23,7 +23,7 @@ import fitsio
 
 # Imports INTERNAL
 import phrosty
-from phrosty.imagesubtraction import sky_subtract, stampmaker
+from phrosty.imagesubtraction import interpolate_over_bad_pixels, sky_subtract, stampmaker
 from sfft.SpaceSFFTFlow import SpaceSFFT_Flow
 from snappl.dbclient import SNPITDBClient
 from snappl.diaobject import DiaObject
@@ -488,13 +488,12 @@ class Pipeline:
 
         """
 
-        # SFFT needs FITS headers with a WCS and with NAXIS[12]
         hdr_sci = sci_image.image.get_wcs().get_astropy_wcs().to_header( relax=True )
         hdr_sci.insert( 0, ('NAXIS', 2) )
         hdr_sci.insert( 'NAXIS', ('NAXIS1', sci_image.image.data.shape[1] ), after=True )
         hdr_sci.insert( 'NAXIS1', ('NAXIS2', sci_image.image.data.shape[0] ), after=True )
         data_sci = sci_image.skysub_img.data
-        noise_sci = sci_image.image.noise
+        noise_sci, _ = interpolate_over_bad_pixels(sci_image.image.noise, sci_image.image.flags)
         var_sci = noise_sci ** 2
 
         hdr_templ = templ_image.image.get_wcs().get_astropy_wcs().to_header( relax=True )
@@ -502,7 +501,7 @@ class Pipeline:
         hdr_templ.insert( 'NAXIS', ('NAXIS1', templ_image.image.data.shape[1] ), after=True )
         hdr_templ.insert( 'NAXIS1', ('NAXIS2', templ_image.image.data.shape[0] ), after=True )
         data_templ = templ_image.skysub_img.data
-        noise_templ = templ_image.image.noise
+        noise_templ, _ = interpolate_over_bad_pixels(templ_image.image.noise, templ_image.image.flags)
         var_templ = noise_templ ** 2
 
         sci_psf = sci_image.psf_data
@@ -562,7 +561,7 @@ class Pipeline:
             All values are floats.
 
         """
-
+        import pdb; pdb.set_trace()
         forcecoords = Table([[float(pxcoords[0])], [float(pxcoords[1])]], names=["x", "y"])
         init = img.ap_phot( forcecoords, ap_r=ap_r )
         init.rename_column( 'aperture_sum', 'flux_init' )

--- a/phrosty/pipeline.py
+++ b/phrosty/pipeline.py
@@ -67,7 +67,7 @@ class PipelineImage:
 
         # Intermediate files
         if self.keep_intermediate:
-            # Set to None. The path gets defined later on.
+            # The path gets defined later on.
             # They have to be defined here in __init__ so that they exist
             # and are accessible in later functions.
             self.skysub_img = {}
@@ -157,11 +157,6 @@ class PipelineImage:
             PSF stamp. If this function fails, None is returned.
 
         """
-
-        # TODO: right now snappl.psf.PSF.get_psf_object just
-        #   passes the keyword arguments on to whatever makes
-        #   the psf... and it's different for each type of
-        #   PSF.  We need to fix that... somehow....
 
         try:
             wcs = self.image.get_wcs()
@@ -620,7 +615,6 @@ class Pipeline:
         """
 
         # Do photometry on stamp because it will read faster.
-        # (We hope.  But CFS latency will kill you at 1 byte.)
         SNLogger.debug( "...make_phot_info_dict reading stamp and psf" )
 
         # Required results keys
@@ -637,6 +631,11 @@ class Pipeline:
         # Required results keys
         results_dict['observation_id'] = str(sci_image.image.observation_id)
         results_dict['sca'] = sci_image.image.sca
+        results_dict['sky_rms'] = sci_image.skyrms
+        pix_x, pix_y = sci_image.image.get_wcs().world_to_pixel( self.diaobj.ra,
+                                                                 self.diaobj.dec )
+        results_dict['pix_x'] = pix_x
+        results_dict['pix_y'] = pix_y
 
         # phrosty results keys
         results_dict['science_name'] = sci_image.image.name
@@ -985,16 +984,12 @@ class Pipeline:
         savepath : str
             Savepath for FITS file.
         """
-        # try:
         if header is not None:
             hdr_dict = dict(header.items())
         else:
             hdr_dict = None
 
         fitsio.write( savepath, data, header=hdr_dict, clobber=True )
-        # except Exception as e:
-        #     SNLogger.exception( f"Exception writing FITS image {savepath}: {e}" )
-        #     raise
 
     def clear_contents( self, directory ):
         """Delete contents of a directory. Used to clear temporary
@@ -1090,7 +1085,7 @@ class Pipeline:
                 for sci_image in self.science_images:
                     SNLogger.info( f"Processing {sci_image.image.name} minus {templ_image.image.name}" )
                     sfftifier = None
-                    i_failed_gpu = False # We haven't failed yet.
+                    i_failed_gpu = False # We haven't failed yet. YET.
                     fail_info = {
                                  'science': sci_image.fail_info,
                                  'template': templ_image.fail_info
@@ -1127,9 +1122,6 @@ class Pipeline:
                                     self.failures['align_and_preconvolve'].append(fail_info)
 
                     if 'subtract' in steps and not i_failed_gpu:
-                        # After this step is done, two more fields in sfftifier are set:
-                        #    Solution  : Matching kernel parameterization (coefficients)
-                        #    PixA_DIFF : difference image
                         SNLogger.info( "...subtract" )
                         with nvtx.annotate( "subtraction", color=0x44ccff ):
                             try:
@@ -1146,13 +1138,6 @@ class Pipeline:
                                     self.failures['subtract'].append(fail_info)
 
                     if 'find_decorrelation' in steps and not i_failed_gpu:
-                        # This step does ...
-                        # After it's done, the following fields of sfftifier are set:
-                        #   Solution : CPU copy of Solution
-                        #   FKDECO : result of PureCupy_Decorrelation_Calculator.PCDC
-                        # In addition the two local varaibles diff_var and diff_var_path are set.
-                        #   diff_var : variance in difference image, on GPU
-                        #   diff_var_path : where we want to write diff_var in self.dia_out_dir
                         SNLogger.info( "...find_decorrelation" )
                         with nvtx.annotate( "find_decor", color=0xcc44ff ):
                             try:
@@ -1315,7 +1300,7 @@ class Pipeline:
                 # original sci path, savedir, savename
                 sci_orig_stamp_args = ( (si.image, self.dia_out_dir, f'stamp_{str(si.image.name)}', 'data')
                                          for si in self.science_images)
-                # template path, savedir, savename
+                # original template path, savedir, savename
                 templstamp_args = ( (ti.image, self.dia_out_dir, f'stamp_{str(ti.image.name)}', 'data')
                                     for ti in self.template_images )
                 if self.nwrite > 1:
@@ -1336,7 +1321,6 @@ class Pipeline:
 
                     # Save stamps for decorrelated difference image, zero point image (decorrelated sky-subtracted
                     # science image), and variance image for decorrelated difference image
-
                     with Pool( self.nwrite ) as sci_stamp_pool:
                         for sci_image in self.science_images:
                             for templ_image in self.template_images:
@@ -1350,14 +1334,14 @@ class Pipeline:
                         sci_stamp_pool.join()
 
                 else:
-                    # Make stamp of just the template image
+                    # Make and save stamp of just the template image
                     for tsargs in templstamp_args:
                         try:
                             partialstamp(*tsargs)
                         except Exception:
                             self.failures['make_stamps'].append(tsargs[0].fail_info)
 
-                    # Make stamp of just the science image
+                    # Make and save stamp of just the science image
                     for sosargs in sci_orig_stamp_args:
                         try:
                             partialstamp(*sosargs)

--- a/phrosty/pipeline.py
+++ b/phrosty/pipeline.py
@@ -1342,7 +1342,7 @@ class Pipeline:
                     for tsargs in templstamp_args:
                         try:
                             partialstamp(*tsargs)
-                        except Exception as {e}:
+                        except Exception as e:
                             SNLogger.warning( f"Stampifying the original template images failed because: {e}" )
                             self.failures['make_stamps'].append(tsargs[0].fail_info)
 

--- a/phrosty/pipeline.py
+++ b/phrosty/pipeline.py
@@ -1232,9 +1232,15 @@ class Pipeline:
 
                                 with nvtx.annotate( "submit writefits", color=0xff8888 ):
                                     SNLogger.info( f"...writefits {savepath}" )
-                                    fits_writer_pool.apply_async( self.write_fits_file,
-                                                                ( cp.asnumpy( decorimg ).T, hdr, savepath ), {},
-                                                                error_callback=partial(log_fits_write_error, savepath) )
+                                    if self.nwrite > 1:
+                                        fits_writer_pool.apply_async( self.write_fits_file,
+                                                                    ( cp.asnumpy( decorimg ).T, hdr, savepath ), {},
+                                                                    error_callback=partial(log_fits_write_error, savepath) )
+                                    else:
+                                        try:
+                                            self.write_fits_file( cp.asnumpy(decorimg).T, hdr, savepath )
+                                        except:
+                                            partial( log_fits_write_error( savepath ) )
                             sci_image.decorr_psf_path[ templ_image.image.name ] = decorr_psf_path
                             sci_image.decorr_zptimg_path[ templ_image.image.name ] = decorr_zptimg_path
                             sci_image.decorr_diff_path[ templ_image.image.name ] = decorr_diff_path
@@ -1393,6 +1399,7 @@ class Pipeline:
                         for templ_image in self.template_images:
                             if templ_image.image.name in sci_image.decorr_diff_path.keys():
                                 try:
+                                    import pdb; pdb.set_trace()
                                     stamp_paths = self.do_stamps( sci_image, templ_image)
                                     self.save_stamp_paths( sci_image, templ_image, stamp_paths )
                                 except Exception:

--- a/phrosty/pipeline.py
+++ b/phrosty/pipeline.py
@@ -561,7 +561,6 @@ class Pipeline:
             All values are floats.
 
         """
-        import pdb; pdb.set_trace()
         forcecoords = Table([[float(pxcoords[0])], [float(pxcoords[1])]], names=["x", "y"])
         init = img.ap_phot( forcecoords, ap_r=ap_r )
         init.rename_column( 'aperture_sum', 'flux_init' )

--- a/phrosty/pipeline.py
+++ b/phrosty/pipeline.py
@@ -386,7 +386,9 @@ class Pipeline:
                                                               observation_id=observation_id,
                                                               sca=sca,
                                                               band=band ) )
-                    except:
+                    except Exception as e:
+                        SNLogger.warning( f"Could not find the image using observation_id, sca, and/or band, \
+                                           so just using the path. Failure: {e}" )
                         imlist.append( self.imgcol.get_image( path=path ))
         return imlist
 
@@ -1187,13 +1189,15 @@ class Pipeline:
                                     SNLogger.info( f"...writefits {savepath}" )
                                     if self.nwrite > 1:
                                         fits_writer_pool.apply_async( self.write_fits_file,
-                                                                    ( sfftifier.op.asnumpy( decorimg ), hdr, savepath ), {},
+                                                                    ( sfftifier.op.asnumpy( decorimg ),
+                                                                      hdr, savepath ), {},
                                                                       error_callback=partial(log_fits_write_error,
                                                                                          savepath) )
                                     else:
                                         try:
                                             self.write_fits_file( sfftifier.op.asnumpy( decorimg ), hdr, savepath )
-                                        except:
+                                        except Exception as e:
+                                            SNLogger.warning( f"FITS writing failure: {e}" )
                                             partial( log_fits_write_error( savepath ) )
                             sci_image.decorr_psf_path[ templ_image.image.name ] = decorr_psf_path
                             sci_image.decorr_zptimg_path[ templ_image.image.name ] = decorr_zptimg_path
@@ -1328,7 +1332,7 @@ class Pipeline:
                                 stamperr_partial = partial(log_stamp_err, sci_image, templ_image)
                                 sci_stamp_pool.apply_async( self.do_stamps, pair, {},
                                                             callback = partial(self.save_stamp_paths,
-                                                                            sci_image, templ_image),
+                                                                               sci_image, templ_image),
                                                             error_callback=stamperr_partial )
                         sci_stamp_pool.close()
                         sci_stamp_pool.join()
@@ -1338,14 +1342,16 @@ class Pipeline:
                     for tsargs in templstamp_args:
                         try:
                             partialstamp(*tsargs)
-                        except Exception:
+                        except Exception as {e}:
+                            SNLogger.warning( f"Stampifying the original template images failed because: {e}" )
                             self.failures['make_stamps'].append(tsargs[0].fail_info)
 
                     # Make and save stamp of just the science image
                     for sosargs in sci_orig_stamp_args:
                         try:
                             partialstamp(*sosargs)
-                        except Exception:
+                        except Exception as e:
+                            SNLogger.warning( f"Stampifying the original science images failed because: {e}" )
                             self.failures['make_stamps'].append(sosargs[0].fail_info)
 
                     for sci_image in self.science_images:
@@ -1354,8 +1360,9 @@ class Pipeline:
                                 try:
                                     stamp_paths = self.do_stamps( sci_image, templ_image)
                                     self.save_stamp_paths( sci_image, templ_image, stamp_paths )
-                                except Exception:
+                                except Exception as e:
                                     if self.catchfailures:
+                                        SNLogger.warning( f"Stampifying the post-SFFT images failed because: {e}" )
                                         self.failures['make_stamps'].append({
                                                                             'science': sci_image.fail_info,
                                                                             'template': templ_image.fail_info

--- a/phrosty/pipeline.py
+++ b/phrosty/pipeline.py
@@ -108,7 +108,7 @@ class PipelineImage:
         self.failure_pair = None
 
     def run_sky_subtract( self, mp=True ):
-        """Run sky subtraction using Source Extractor.
+        """Run sky subtraction using photutils.
 
         Parameters
         ----------

--- a/phrosty/pipeline.py
+++ b/phrosty/pipeline.py
@@ -25,7 +25,7 @@ import fitsio
 # Imports INTERNAL
 import phrosty
 from phrosty.imagesubtraction import sky_subtract, stampmaker
-from sfft.SpaceSFFTCupyFlow import SpaceSFFT_CupyFlow
+from sfft.SpaceSFFTFlow import SpaceSFFT_Flow
 from snappl.dbclient import SNPITDBClient
 from snappl.diaobject import DiaObject
 from snappl.imagecollection import ImageCollection
@@ -482,7 +482,7 @@ class Pipeline:
 
         Returns
         -------
-          sfftifier: SpaceSFFT_CupyFlow
+          sfftifier: SpaceSFFT_Flow
             Use this object for futher SFFT work.  Be sure to
             dereference it to free the prodigious amount of memory it
             allcoates.
@@ -512,24 +512,24 @@ class Pipeline:
         sci_detmask = cp.array( np.ascontiguousarray( sci_image.detmask_img.data.T ) )
         templ_detmask = cp.array( np.ascontiguousarray( templ_image.detmask_img.data.T ) )
 
-        sfftifier = SpaceSFFT_CupyFlow(
-                                        hdr_target=hdr_sci,
-                                        hdr_object=hdr_templ,
-                                        target_skyrms=sci_image.skyrms,
-                                        object_skyrms=templ_image.skyrms,
-                                        PixA_target_GPU=data_sci,
-                                        PixA_object_GPU=data_templ,
-                                        PixA_targetVar_GPU=var_sci,
-                                        PixA_objectVar_GPU=var_templ,
-                                        PixA_target_DMASK_GPU=sci_detmask,
-                                        PixA_object_DMASK_GPU=templ_detmask,
-                                        PSF_target_GPU=sci_psf,
-                                        PSF_object_GPU=templ_psf,
-                                        KerPolyOrder=Config.get().value('photometry.phrosty.kerpolyorder')
-                                      )
+        sfftifier = SpaceSFFT_Flow(
+                                    hdr_target=hdr_sci,
+                                    hdr_object=hdr_templ,
+                                    target_skyrms=sci_image.skyrms,
+                                    object_skyrms=templ_image.skyrms,
+                                    PixA_target=data_sci,
+                                    PixA_object=data_templ,
+                                    PixA_targetVar=var_sci,
+                                    PixA_objectVar=var_templ,
+                                    PixA_target_DMASK=sci_detmask,
+                                    PixA_object_DMASK=templ_detmask,
+                                    PSF_target=sci_psf,
+                                    PSF_object=templ_psf,
+                                    KerPolyOrder=Config.get().value('photometry.phrosty.kerpolyorder')
+                                   )
 
-        sfftifier.resampling_image_mask_psf()
-        sfftifier.cross_convolution()
+        sfftifier.resample_image_mask_psf()
+        sfftifier.cross_convolve()
 
         return sfftifier
 
@@ -1110,7 +1110,7 @@ class Pipeline:
                         i_failed_gpu = True
 
                     if 'align_and_preconvolve' in steps and not i_failed_gpu:
-                        # After this step, sfftifier will be a SpaceSFFT_CupyFlow
+                        # After this step, sfftifier will be a SpaceSFFT_Flow
                         #  object with the following fields filled.  All cupy arrays
                         #  are float64 (even the DMASK!), and all of them are Transposed
                         #  from what's stored in the PipelineImage object
@@ -1118,21 +1118,21 @@ class Pipeline:
                         #    hdr_object : FITS header of template image
                         #    target_skyrms : float, median of sky for science image
                         #    object_skyrms : float, median of sky for template image
-                        #    PixA_target_GPU  : science image data on GPU
-                        #    PixA_Ctarget_GPU : cross-convolved science image with template PSF on GPU
-                        #    PixA_object_GPU  : template image data on GPU
-                        #    PixA_resamp_object_GPU : warped template image data on GPU
-                        #    PixA_Cresampl_object_GPU : cross-convolved template image on GPU
+                        #    PixA_target  : science image data on GPU
+                        #    PixA_Ctarget : cross-convolved science image with template PSF on GPU
+                        #    PixA_object  : template image data on GPU
+                        #    PixA_resamp_object : warped template image data on GPU
+                        #    PixA_Cresampl_object : cross-convolved template image on GPU
                         #    BlankMask_GPU : boolean array, True where PixA_resampl_object_GPU is 0.
-                        #    PixA_targetVar_GPU : variance image for science image, on GPU
-                        #    PixA_objectVar_GPU : variance image for template image, on GPU
-                        #    PiXA_resampl_objectVar_GPU : warped template variance data on GPU
-                        #    PixA_target_DMASK_GPU : detmask for science image, on GPU
-                        #    PixA_object_DMASK_GPU : detmask for template image, on GPU
-                        #    PixA_resampl_object_DMASK_GPU : warped dmask for template image, on GPU
-                        #    PSF_target_GPU : PSF stamp for science image
-                        #    PSF_object_GPU : PSF stamp for template image
-                        #    PSF_resampl_object_GPU : PSF stamp for template image rotated & resampled, on GPU
+                        #    PixA_targetVar : variance image for science image, on GPU
+                        #    PixA_objectVar : variance image for template image, on GPU
+                        #    PiXA_resampl_objectVar : warped template variance data on GPU
+                        #    PixA_target_DMASK : detmask for science image, on GPU
+                        #    PixA_object_DMASK : detmask for template image, on GPU
+                        #    PixA_resampl_object_DMASK : warped dmask for template image, on GPU
+                        #    PSF_target : PSF stamp for science image
+                        #    PSF_object : PSF stamp for template image
+                        #    PSF_resampl_object : PSF stamp for template image rotated & resampled, on GPU
                         #    sci_is_target : True
                         #    GKerHW : 9 (int half-width of matching kernel, full width is 2*GKerHW+1)
                         #    KerPolyOrder : config value of photometry.phrosty.kerpolyorder
@@ -1150,7 +1150,7 @@ class Pipeline:
                                 mess = f"{sci_image.image.name}-{templ_image.image.name}"
                                 aligned_templ_path = self.dia_out_dir / f"aligned_{mess}"
                                 sci_image.aligned_templ_img_path[ templ_image.image.name ] = aligned_templ_path
-                                self.write_fits_file(cp.asnumpy(sfftifier.PixA_resamp_object_GPU.T),
+                                self.write_fits_file(cp.asnumpy(sfftifier.PixA_resamp_object.T),
                                                                 sfftifier.hdr_target, aligned_templ_path)
 
                             except Exception as e:
@@ -1166,11 +1166,11 @@ class Pipeline:
                         SNLogger.info( "...subtract" )
                         with nvtx.annotate( "subtraction", color=0x44ccff ):
                             try:
-                                sfftifier.sfft_subtraction()
+                                sfftifier.sfft_subtract()
                                 mess = f"{sci_image.image.name}-{templ_image.image.name}"
                                 undecorr_diff_path = self.dia_out_dir / f"diff_{mess}"
                                 sci_image.diff_undecorr_img_path[ templ_image.image.name ] = undecorr_diff_path
-                                self.write_fits_file(cp.asnumpy(sfftifier.PixA_DIFF_GPU.T),
+                                self.write_fits_file(cp.asnumpy(sfftifier.PixA_DIFF.T),
                                                                 sfftifier.hdr_target, undecorr_diff_path)
                             except Exception as e:
                                 i_failed_gpu = True
@@ -1218,8 +1218,8 @@ class Pipeline:
                             decorr_zptimg_path = self.dia_out_dir / f"decorr_zptimg_{mess}"
                             decorr_diff_path = self.dia_out_dir / f"decorr_diff_{mess}"
 
-                            images =    [ sfftifier.PixA_DIFF_GPU,
-                                        sfftifier.PixA_Ctarget_GPU, sfftifier.PSF_Ctarget_GPU ]
+                            images =    [ sfftifier.PixA_DIFF,
+                                        sfftifier.PixA_Ctarget, sfftifier.PSF_Ctarget ]
                             savepaths = [ decorr_diff_path,
                                         decorr_zptimg_path,         decorr_psf_path ]
                             headers =   [ sfftifier.hdr_target,
@@ -1261,33 +1261,33 @@ class Pipeline:
 
                         write_filepaths = {'aligned': [['img',
                                                         f'{templ_image.image.name}_-_{sci_image.image.name}',
-                                                        cp.asnumpy(sfftifier.PixA_resamp_object_GPU.T),
+                                                        cp.asnumpy(sfftifier.PixA_resamp_object.T),
                                                         sfftifier.hdr_target],
                                                         ['var',
                                                          f'{templ_image.image.name}_-_{sci_image.image.name}',
-                                                         cp.asnumpy(sfftifier.PixA_resamp_objectVar_GPU.T),
+                                                         cp.asnumpy(sfftifier.PixA_resamp_objectVar.T),
                                                          sfftifier.hdr_target],
                                                        ['psf',
                                                         f'{templ_image.image.name}_-_{sci_image.image.name}',
-                                                        cp.asnumpy(sfftifier.PSF_target_GPU.T),
+                                                        cp.asnumpy(sfftifier.PSF_target.T),
                                                         sfftifier.hdr_target],
                                                        ['detmask',
                                                         f'{sci_image.image.name}_-_{templ_image.image.name}',
-                                                        cp.asnumpy(sfftifier.PixA_resamp_object_DMASK_GPU.T),
+                                                        cp.asnumpy(sfftifier.PixA_resamp_object_DMASK.T),
                                                         sfftifier.hdr_target]
                                                        ],
                                            'convolved': [['img',
                                                          f'{sci_image.image.name}_-_{templ_image.image.name}.fits',
-                                                         cp.asnumpy(sfftifier.PixA_Ctarget_GPU.T),
+                                                         cp.asnumpy(sfftifier.PixA_Ctarget.T),
                                                          sfftifier.hdr_target],
                                                          ['img',
                                                          f'{templ_image.image.name}_-_{sci_image.image.name}.fits',
-                                                         cp.asnumpy(sfftifier.PixA_Cresamp_object_GPU.T),
+                                                         cp.asnumpy(sfftifier.PixA_Cresamp_object.T),
                                                          sfftifier.hdr_target]
                                                         ],
                                            'diff':     [['img',
                                                         f'{sci_image.image.name}_-_{templ_image.image.name}.fits',
-                                                        cp.asnumpy(sfftifier.PixA_DIFF_GPU.T),
+                                                        cp.asnumpy(sfftifier.PixA_DIFF.T),
                                                         sfftifier.hdr_target]
                                                        ],
                                            'match_kernel': [['img',
@@ -1300,11 +1300,11 @@ class Pipeline:
                                         #               Don't worry about it.
                                            'decorr':   [['kernel_real',
                                                         f'{sci_image.image.name}_-_{templ_image.image.name}.fits',
-                                                        cp.asnumpy(sfftifier.FKDECO_GPU.T).real,
+                                                        cp.asnumpy(sfftifier.FKDECO.T).real,
                                                         sfftifier.hdr_target],
                                                         ['kernel_imag',
                                                         f'{sci_image.image.name}_-_{templ_image.image.name}.fits',
-                                                        cp.asnumpy(sfftifier.FKDECO_GPU.T).imag,
+                                                        cp.asnumpy(sfftifier.FKDECO.T).imag,
                                                         sfftifier.hdr_target],
                                                        ]
                                           }
@@ -1399,7 +1399,6 @@ class Pipeline:
                         for templ_image in self.template_images:
                             if templ_image.image.name in sci_image.decorr_diff_path.keys():
                                 try:
-                                    import pdb; pdb.set_trace()
                                     stamp_paths = self.do_stamps( sci_image, templ_image)
                                     self.save_stamp_paths( sci_image, templ_image, stamp_paths )
                                 except Exception:

--- a/phrosty/tests/11_instances_science_2.csv
+++ b/phrosty/tests/11_instances_science_2.csv
@@ -1,3 +1,3 @@
 path observation_id sca mjd band
-output_images_galid_force0/SNPIT_VISIT606650033_WFI01_F129_L2.asdf 1 60665.0033 J129
-output_images_galid_force0/SNPIT_VISIT606750033_WFI01_F129_L2.asdf 1 60675.0033 J129
+output_images_galid_force0/SNPIT_VISIT606650033_WFI01_F129_L2.asdf 606650033 1 60665.0033 J129
+output_images_galid_force0/SNPIT_VISIT606750033_WFI01_F129_L2.asdf 606750033 1 60675.0033 J129

--- a/phrosty/tests/11_instances_science_2.csv
+++ b/phrosty/tests/11_instances_science_2.csv
@@ -1,0 +1,3 @@
+path observation_id sca mjd band
+output_images_galid_force0/SNPIT_VISIT606650033_WFI01_F129_L2.asdf 1 60665.0033 J129
+output_images_galid_force0/SNPIT_VISIT606750033_WFI01_F129_L2.asdf 1 60675.0033 J129

--- a/phrosty/tests/11_instances_templates_1.csv
+++ b/phrosty/tests/11_instances_templates_1.csv
@@ -1,0 +1,2 @@
+path observation_id sca mjd band
+output_images_galid_force0/SNPIT_VISIT607650033_WFI01_F129_L2.asdf 1 60765.0033 J129

--- a/phrosty/tests/11_instances_templates_1.csv
+++ b/phrosty/tests/11_instances_templates_1.csv
@@ -1,2 +1,2 @@
 path observation_id sca mjd band
-output_images_galid_force0/SNPIT_VISIT607650033_WFI01_F129_L2.asdf 1 60765.0033 J129
+output_images_galid_force0/SNPIT_VISIT607650033_WFI01_F129_L2.asdf 607650033 1 60765.0033 J129

--- a/phrosty/tests/phrosty_test_config.yaml
+++ b/phrosty/tests/phrosty_test_config.yaml
@@ -26,5 +26,5 @@ photometry:
       radius_cut_detmask: 2
 
     psf:
-      type: A25ePSF
+      type: gaussian
       params: {}


### PR DESCRIPTION
Changes include:
- phrosty no longer uses calls to Source Extractor (via SFFT utils) in sky subtraction. phrosty now uses the same function that (the current main branch of) sidecar uses, which is photutils-based. In light of this, I have opened a new issue in snappl to move sky subtraction in there since it is now a fully shared function: https://github.com/Roman-Supernova-PIT/snappl/issues/198
- Needed to implement an additional function for RomanDatamodelImage in snappl so that phrosty continues to have full functionality with FITS while also moving forward to accommodate ASDF. See: https://github.com/Roman-Supernova-PIT/snappl/pull/200
- Include interpolation over bad pixels in original input images like MWV's code in sidecar. 
- Addresses https://github.com/Roman-Supernova-PIT/phrosty/pull/196
- Addresses https://github.com/Roman-Supernova-PIT/phrosty/pull/195 except for NEA field